### PR TITLE
Add hint when adding new link that length might be off

### DIFF
--- a/src/main/java/org/matsim/networkEditor/controllers/MainController.java
+++ b/src/main/java/org/matsim/networkEditor/controllers/MainController.java
@@ -1005,6 +1005,9 @@ public class MainController {
         message.setTextFill(Color.GRAY);
         grid.add(message, 0, 8, 2, 1);
 
+        Label linkHint = new Label("Length might not be exact if 1 unit in x/y does not refer to 1m distance in the selected system.");
+        linkHint.setTextFill(Color.DARKRED);
+        grid.add(linkHint, 0, 10, 2, 1);
         // Enable/Disable button
         javafx.scene.Node createButton = dialog.getDialogPane().lookupButton(createButtonType);
         createButton.setDisable(false);


### PR DESCRIPTION
It is possible that the link length has a weird value when the system chosen is not a projected one, since the projected calculation of distance is used in the editor. 

This push is adding a hint into the link creation window, to inform the user that the value might not be reflective of the true link length.